### PR TITLE
Built-in --fake support + a bunch of fixes/tweaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,7 +479,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bb0228f477c0900c880fd78c8759b95c7636dbd7842707f49e132378aa2acdc"
 dependencies = [
  "heck 0.4.1",
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 2.0.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -827,11 +827,10 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "2.0.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24"
+checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
 dependencies = [
- "toml_datetime",
  "toml_edit 0.20.2",
 ]
 
@@ -1062,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
  "serde",
 ]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This is a fork of [phog](https://gitlab.com/mobian1/phog).
 
 ```
 sudo dnf copr enable samcday/phrog
+# If you want to test the latest and/or greatest
+# sudo dnf copr enable samcday/phrog-nightly
 sudo dnf install phrog
 ```
 
@@ -23,20 +25,18 @@ For now, you must build from source, see the Development section below.
 
 ### Running
 
-`phrog` is primarily intended to run via greetd. That is, your `/etc/greetd/config.toml` should
-look something like this:
+`phrog` is primarily intended to run via greetd - your `/etc/greetd/config.toml` should
+look like this:
 
 ```
 [default_session]
 command = "systemd-cat --identifier=phrog phoc -E phrog"
-# or this if you are using postmarketOS:
-command = "dbus-run-session phoc -E phrog"
 ```
 
-You can also run it directly in a `greetd-fakegreet` session, assuming you have that binary installed:
+You can also run/test it directly in a faked greetd session:
 
 ```
-FAKEGREET=1 phoc -E "fakegreet phrog"
+phrog --fake
 ```
 
 ## Development
@@ -75,10 +75,10 @@ Build the app.
 cargo build
 ```
 
-Have a fake conversation with greetd.
+Run the app in test mode.
 
 ```
-FAKEGREET=1 phoc -E "fakegreet ./target/debug/phrog"
+./target/debug/phrog --fake
 ```
 
 [phosh-deps]: https://gitlab.gnome.org/World/Phosh/phosh#dependencies

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -12,23 +12,24 @@ impl Shell {
     }
 }
 
-impl Default for Shell {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 mod imp {
+    use std::cell::Cell;
     // use crate::keypad_shuffle::ShuffleKeypadQuickSetting;
     use crate::lockscreen::Lockscreen;
-    use gtk::glib::Type;
+    use gtk::glib::{Properties, Type};
     use gtk::prelude::StaticType;
     use gtk::subclass::prelude::{ObjectImpl, ObjectSubclass};
-    use gtk::{gio, glib};
+    use gtk::glib;
+    use gtk::prelude::*;
+    use gtk::subclass::prelude::*;
     use libphosh::subclass::shell::ShellImpl;
 
-    #[derive(Default)]
-    pub struct Shell;
+    #[derive(Default, Properties)]
+    #[properties(wrapper_type = super::Shell)]
+    pub struct Shell {
+        #[property(get, set)]
+        fake_greetd: Cell<bool>,
+    }
 
     #[glib::object_subclass]
     impl ObjectSubclass for Shell {
@@ -37,6 +38,7 @@ mod imp {
         type ParentType = libphosh::Shell;
     }
 
+    #[glib::derived_properties]
     impl ObjectImpl for Shell {}
 
     impl ShellImpl for Shell {

--- a/src/users.rs
+++ b/src/users.rs
@@ -6,12 +6,6 @@ const DEFAULT_MIN_UID: uzers::uid_t = 1000;
 const DEFAULT_MAX_UID: uzers::uid_t = 60000;
 
 pub fn users() -> HashMap<String, String> {
-    if std::env::var("FAKEGREET").unwrap_or_default() == "1" {
-        let mut fake = HashMap::new();
-        fake.insert("user".to_string(), "Fake User".to_string());
-        return fake;
-    }
-
     let uid_range = uid_range();
     unsafe { uzers::all_users() }
         .filter(|u| uid_range.contains(&u.uid()))


### PR DESCRIPTION
new "fakegreet" is a dozen or so lines to any% the lockscreen to success, it's activated with --fake

phoc isn't always being spawned any more. it's just a bool so now hardcoded to launching phoc, but only if explicitly requested to do so with --phoc

the lockscreen greetd conversation handling is cleaned up. still not where i want it but getting there. it gracefully handles being launched with no greetd socket by returning errors that end up showing on the keypad page.

fixes screen fadeout on successful login with real greetd as well - closes #20 