### PR TITLE
Reenable packit

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,32 @@
+# https://packit.dev/docs/configuration/
+specfile_path: phrog.spec
+files_to_sync:
+  - phrog.spec
+  - .packit.yaml
+upstream_package_name: phrog
+downstream_package_name: phrog
+jobs:
+  # Build PRs
+  - job: copr_build
+    trigger: pull_request
+    additional_repos: [copr://samcday/phrog-nightly]
+    targets:
+      - fedora-40-aarch64
+      - fedora-40-x86_64
+      - fedora-41-aarch64
+      - fedora-41-x86_64
+      - fedora-rawhide-aarch64
+      - fedora-rawhide-x86_64
+
+  # Build main commits in samcday/phrog-nightly COPR
+  - job: copr_build
+    trigger: commit
+    branch: main
+    owner: samcday
+    project: phrog-nightly
+
+  # Build tagged releases in samcday/phrog COPR
+  - job: copr_build
+    trigger: release
+    owner: samcday
+    project: phrog

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -11,8 +11,6 @@ jobs:
     trigger: pull_request
     additional_repos: [copr://samcday/phrog-nightly]
     targets:
-      - fedora-40-aarch64
-      - fedora-40-x86_64
       - fedora-41-aarch64
       - fedora-41-x86_64
       - fedora-rawhide-aarch64

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Not yet available in official repositories, but [an MR is pending][debian-mr].
 
 ### Fedora
 
-Not yet available in official repositories, but [a COPR][copr] is maintained:
+Not yet available in official repositories, but [a COPR][copr] is maintained (**for Fedora 41 and higher**):
 
 ```
 sudo dnf copr enable samcday/phrog

--- a/phrog.spec
+++ b/phrog.spec
@@ -1,8 +1,8 @@
 %global cargo_install_lib 0
-%global phosh_ver 0.42
+%global phosh_ver 0.43
 
 Name:           phrog
-Version:        0.42.0
+Version:        0.43.0
 Release:        %autorelease
 Summary:        Greetd-compatible greeter for mobile phones
 License:        GPL-3.0-only


### PR DESCRIPTION
Related to #23 

The COPR repos now contain some initial packaging for the `libphosh` + `libphosh-sys` crates I generated with `rust2rpm`.