### PR TITLE
gha: Build all archs in Alpine workflow

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -20,8 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Always build x64 in main + PRs, but only other architectures for tagged releases
-        arch: ${{ startsWith(github.ref, 'refs/tags/') && fromJSON('["x86_64", "aarch64"]') || fromJSON('["x86_64"]') }}
+        arch:
+          - x86_64
+          - aarch64
     steps:
       - uses: actions/checkout@v4
       - uses: jirutka/setup-alpine@v1


### PR DESCRIPTION
Was previously disabled due to qemu aarch64 user emu being too slow, but that was because we were building a static libphosh as well. Should be much less painful now.