### PR TITLE
data: Add example greetd setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ It is the spiritual successor of [phog][].
 command = "systemd-cat --identifier=phrog phrog"
 ```
 
-Then run greetd however your distro prefers you to.
+Then run greetd however your distro prefers you to, see the
+[example-config](./example-config) directory for an example greetd config and
+startup script that launches greetd in a way suitable for mobile use.
 
 You can also test it outside greetd, nested in your favourite Wayland desktop environment:
 

--- a/example-config/phrog-session
+++ b/example-config/phrog-session
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+PHOC_INI="/usr/share/phrog/phoc.ini"
+
+help()
+{
+  cat <<EOF
+phrog - Session start script for Phrog
+
+This is usually invoked by a display manager but you can
+also run it from a tty.
+
+Usage: phrog
+EOF
+  exit 0
+}
+
+
+version()
+{
+   /usr/libexec/phrog --version
+   exit 0
+}
+
+case "$1" in
+  -h|-\?|--help)
+    help
+    ;;
+  --version)
+    version
+    ;;
+esac
+
+if [ -f /etc/phrog/phoc.ini ]; then
+  PHOC_INI=/etc/phrog/phoc.ini
+fi
+
+OSK=$(sed -ne 's/^Exec=\(.*\)/\1/p' /usr/share/applications/sm.puri.OSK0.desktop)
+[ -n "${OSK}" ] || OSK=squeekboard
+
+[ -n "$WLR_BACKENDS" ] || WLR_BACKENDS=drm,libinput
+export WLR_BACKENDS
+# Run phrog through a login shell so it picks
+# variables from /etc/profile.d (XDG_*)
+exec /usr/bin/phoc -S -C "${PHOC_INI}" -E "bash -lc '/usr/libexec/phrog & $OSK'"

--- a/example-config/phrog.toml
+++ b/example-config/phrog.toml
@@ -1,0 +1,8 @@
+[terminal]
+vt = 7
+
+# The default session, also known as the greeter.
+[default_session]
+command = "systemd-cat --identifier=phrog /usr/bin/phrog"
+# The user the phrog runs as. Make sure the users home directory is writable.
+#user = "_greetd"


### PR DESCRIPTION
As we need to run phoc and an OSK it's good to have a working example.

This was taken from Debian and originally authored by

Arnaud Ferraris <aferraris@debian.org>

and is close to what Phosh uses for session startup.

It's not installed anywhere atm,