### PR TITLE
tests: Use gdk::Monitor for screen geometry

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -90,8 +90,11 @@ pub fn test_init() -> Test {
     shell.connect_ready(clone!(@strong ready_called2 => move |shell| {
         ready_called2.store(true, Ordering::Relaxed);
 
-        let (_, _, width, height) = shell.usable_area();
-        let vp = VirtualPointer::new(wayland_client::Connection::connect_to_env().unwrap(), width as _, height as _);
+        let display = gtk::gdk::Display::default().unwrap();
+        let monitor = display.monitor(0).unwrap();
+        let screen_geom = monitor.geometry();
+        let vp = VirtualPointer::new(wayland_client::Connection::connect_to_env().unwrap(),
+            screen_geom.width() as u32, screen_geom.height() as u32);
         let kb = VirtualKeyboard::new(wayland_client::Connection::connect_to_env().unwrap());
         ready_tx.send_blocking((vp, kb)).expect("notify ready failed");
     }));

--- a/tests/keypad_shuffle.rs
+++ b/tests/keypad_shuffle.rs
@@ -1,6 +1,6 @@
 pub mod common;
 
-use gtk::glib;
+use gtk::{gdk, glib};
 use gtk::glib::clone;
 use libphosh::prelude::ShellExt;
 use common::*;
@@ -50,7 +50,10 @@ fn keypad_shuffle() {
 
         glib::timeout_future(Duration::from_millis(1000)).await;
 
-        vp.click_at((shell.usable_area().2 / 2) as _, 0).await;
+        let display = gtk::gdk::Display::default().unwrap();
+        let monitor = display.monitor(0).unwrap();
+        let screen_geom = monitor.geometry();
+        vp.click_at((screen_geom.width() / 2) as _, 0).await;
         glib::timeout_future(Duration::from_millis(500)).await;
         vp.click_on(&shell.keypad_shuffle_qs().unwrap().imp().info.clone()).await;
         glib::timeout_future(Duration::from_millis(500)).await;


### PR DESCRIPTION
Currently using PhoshShell.usable_area, but this will likely not end up being public API when the surface area of libphosh is reduced.