### PR TITLE
Various lockscreen tweaks/fixes

### DIFF
--- a/src/keypad_shuffle.rs
+++ b/src/keypad_shuffle.rs
@@ -10,7 +10,6 @@ mod imp {
     use gtk::gio::Settings;
     use gtk::glib::clone;
     use gtk::glib::subclass::InitializingObject;
-    use gtk::prelude::Cast;
     use gtk::prelude::InitializingWidgetExt;
     use gtk::prelude::SettingsExt;
     use gtk::prelude::SettingsExtManual;
@@ -58,10 +57,7 @@ mod imp {
     impl ObjectImpl for ShuffleKeypadQuickSetting {
         fn constructed(&self) {
             self.parent_constructed();
-            libphosh::Shell::default()
-                .downcast::<Shell>()
-                .unwrap()
-                .set_keypad_shuffle_qs(self.obj().clone());
+            Shell::default().set_keypad_shuffle_qs(self.obj().clone());
 
             let settings = Settings::new("sm.puri.phosh.lockscreen");
             settings

--- a/src/lockscreen.rs
+++ b/src/lockscreen.rs
@@ -217,11 +217,7 @@ mod imp {
         }
 
         async fn greetd_req(&self, req: Request) -> anyhow::Result<Response> {
-            if libphosh::Shell::default()
-                .downcast::<Shell>()
-                .unwrap()
-                .fake_greetd()
-            {
+            if Shell::default().fake_greetd() {
                 return fake_greetd_interaction(req);
             }
             if self.greetd.borrow().is_none() {
@@ -271,7 +267,7 @@ mod imp {
                 Response::Success => {
                     self.obj().set_unlock_status("Success. Logging in...");
                     self.start_session().await.unwrap();
-                    libphosh::Shell::default().fade_out(0);
+                    Shell::default().fade_out(0);
                     // Keep this timeout in sync with fadeout animation duration in phrog.css
                     timeout_add_once(Duration::from_millis(500), || {
                         gtk::main_quit();

--- a/src/lockscreen.rs
+++ b/src/lockscreen.rs
@@ -119,9 +119,11 @@ mod imp {
                 glib::spawn_future_local(clone!(@weak ls => async move {
                     // Page is lockscreen, begin greetd conversation.
                     if ls.page() == LockscreenPage::Unlock {
+                        this.obj().set_default_page(LockscreenPage::Unlock);
                         this.create_session().await;
                     } else {
                         // No longer on unlock, cancel session.
+                        this.obj().set_default_page(LockscreenPage::Extra);
                         this.cancel_session().await;
                     }
                 }));
@@ -138,7 +140,6 @@ mod imp {
                 // If there's only one user and one session, set the default + active page to the keypad.
                 if session_count == 1 && user_count == 1 {
                     self_obj.set_page(LockscreenPage::Unlock);
-                    self_obj.set_default_page(LockscreenPage::Unlock);
                 }
             }));
 

--- a/src/lockscreen.rs
+++ b/src/lockscreen.rs
@@ -188,6 +188,7 @@ mod imp {
             self.session.replace(user.clone());
             let username = user.unwrap();
             info!("creating greetd session for user {}", username);
+            self.obj().set_unlock_status("Please wait...");
             self.obj().set_sensitive(false);
             let mut req = Some(Request::CreateSession { username });
             while let Some(next_req) = req.take() {
@@ -320,6 +321,7 @@ mod imp {
     impl LockscreenImpl for Lockscreen {
         fn unlock_submit(&self) {
             glib::spawn_future_local(clone!(@weak self as this => async move {
+                this.obj().set_unlock_status("Please wait...");
                 this.obj().set_sensitive(false);
                 let mut req = Some(Request::PostAuthMessageResponse {
                     response: Some(this.obj().pin_entry().to_string())

--- a/src/lockscreen.rs
+++ b/src/lockscreen.rs
@@ -103,6 +103,10 @@ mod imp {
             let self_obj = self.obj();
             let usp = UserSessionPage::new();
 
+            // Default unlock status in PhoshLockscreen is "Enter Passcode", which doesn't make
+            // sense in our case.
+            self_obj.set_unlock_status("");
+
             // Insert the UserSessionPage widget into the "extra page" of Phosh.Lockscreen.
             // This sits in-between the Info and Unlock (keypad) pages.
             // We default to this page (which means inactivity bounces user back to it).

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,4 +1,4 @@
-use glib::Object;
+use glib::{Cast, Object};
 use gtk::glib;
 
 static G_LOG_DOMAIN: &str = "phrog";
@@ -12,6 +12,12 @@ impl Shell {
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Object::builder().build()
+    }
+}
+
+impl Default for Shell {
+    fn default() -> Self {
+        libphosh::Shell::default().downcast::<Shell>().unwrap()
     }
 }
 

--- a/src/user_session_page.rs
+++ b/src/user_session_page.rs
@@ -26,7 +26,7 @@ impl UserSessionPage {
     }
 
     pub fn session(&self) -> SessionObject {
-        let shell = libphosh::Shell::default().downcast::<Shell>().unwrap();
+        let shell = Shell::default();
         let session_idx = self.imp().row_sessions.selected_index() as u32;
         shell.sessions().unwrap()
             .item(session_idx)
@@ -103,7 +103,7 @@ mod imp {
             self.parent_constructed();
 
             let settings = Settings::new(APP_ID);
-            let shell = libphosh::Shell::default().downcast::<Shell>().unwrap();
+            let shell = Shell::default();
             let conn = shell.imp().dbus_connection.clone().into_inner().unwrap();
 
             self.box_users

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -293,7 +293,7 @@ pub fn keypad_digit(grid: &gtk::Grid, digit: i32) -> gtk::Widget {
 }
 
 pub fn fade_quit() {
-    libphosh::Shell::default().fade_out(0);
+    Shell::default().fade_out(0);
     // Keep this timeout in sync with fadeout animation duration in phrog.css
     timeout_add_once(Duration::from_millis(500), || {
         gtk::main_quit();


### PR DESCRIPTION
Cleaned up a few parts of the lockscreen code to be more readable and better annotated, since there's a lot of dragons in that area. Fixed the issue with inactivity bouncing a user back to user/session page (so this closes #97), and hopefully made the interactions more robust and more user-friendly overall.