### PR TITLE
ci: split build-image into separate workflow

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,40 @@
+name: build-image
+
+on:
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  packages: write
+  pull-requests: write
+
+jobs:
+  build-image:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: get CI image hash
+        id: hash
+        run: |
+          set -uexo pipefail
+          echo "value=${{ hashFiles('.github/Dockerfile') }}" >> $GITHUB_OUTPUT
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .github/
+          file: .github/Dockerfile
+          push: true
+          tags: ghcr.io/samcday/phrog-ci:${{ steps.hash.outputs.value }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,37 +23,21 @@ permissions:
   pull-requests: write
 
 jobs:
-  build-image:
+  image-hash:
     runs-on: ubuntu-24.04
     outputs:
       hash: ${{ steps.hash.outputs.value }}
     steps:
       - uses: actions/checkout@v4
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
       - name: get CI image hash
         id: hash
         run: |
           set -uexo pipefail
           echo "value=${{ hashFiles('.github/Dockerfile') }}" >> $GITHUB_OUTPUT
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .github/
-          file: .github/Dockerfile
-          push: true
-          tags: ghcr.io/samcday/phrog-ci:${{ steps.hash.outputs.value }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
   build:
-    needs: build-image
+    needs: image-hash
     runs-on: ubuntu-24.04
-    container: ghcr.io/samcday/phrog-ci:${{ needs.build-image.outputs.hash }}
+    container: ghcr.io/samcday/phrog-ci:${{ needs.image-hash.outputs.hash }}
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
The current setup doesn't work with pull requests, even if no changes were made to the CI Dockerfile.

So instead, split the build-image job into a separate workflow that is *only* triggered manually. If someone submits a PR that updates the CI image, a maintainer with admin/write access must cherry-pick those commits into a branch, push that to the origin repo, and run this workflow on that branch.

I think there's a better way to do this with pull_request_target, but I need to wrap my brain around the security implications first.