### PR TITLE
packagin/postinst: Allow systemd reload to fail

### DIFF
--- a/debian/phrog.postinst
+++ b/debian/phrog.postinst
@@ -4,8 +4,8 @@ set -e
 
 if [ "$1" = "configure" ]; then
     # Ensure our config fragments are taken into account
-    deb-systemd-invoke --system daemon-reload
-    deb-systemd-invoke --user daemon-reload
+    systemctl --system daemon-reload >/dev/null || true
+    systemctl --user daemon-reload >/dev/null || true
 fi
 
 #DEBHELPER#


### PR DESCRIPTION
During boostrapping of images there's no systemd yet so allow it to fail. This matches the behavior of the postrm snippets that dh_systemd creates. Since we don't care about policy-rc.d use systemctl directly.

This hopefully unbreaks the phosh nightly builds

https://salsa.debian.org/agx/phosh-recipes/-/jobs/7558422#L5481

(we didn't notice earlier as meta-phosh still had a dependency on phog and pulled that in, I've removed phog from the archive now and so we hit this)