### PR TITLE
build: Bump libphosh to 0.0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ glob = "0.3.1"
 greetd_ipc = { version = "0.10.0", features = ["sync-codec"] }
 async-channel = "2.2.1"
 anyhow = "1.0.82"
-libphosh = "0.0.6"
+libphosh = "0.0.7"
 clap = { version = "4.5.4", features = ["derive"] }
 wayland-client = "0.31"
 zbus = { version = "5", default-features = false, features = ["blocking", "async-io"] }


### PR DESCRIPTION
This one builds with Phosh 0.49 but is otherwise ABI compatible.

I'll make the next libphosh release 0.1.0 so we don't have to play catch-up with ABI compatible minor versions.