### PR TITLE
d/control: Use stevia

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -64,7 +64,7 @@ Depends:
  librsvg2-common,
  phoc,
  polkitd,
- phosh-osk-stub |squeekboard,
+ phosh-osk-stevia,
 Conflicts: phog
 Description: Greetd-compatible greeter for mobile phones
  Phrog is a graphical greeter speaking the `greetd` protocol and aimed at mobile


### PR DESCRIPTION
It's the default keyboard. Users can still use squeeboard but we unsure a supported fallback is always installed.

This is needed to unbreak the nightly builds.