### PR TITLE
data: Add phrog specific schema overrides

### DIFF
--- a/data/00_mobi.phosh.Phrog.gschema.override
+++ b/data/00_mobi.phosh.Phrog.gschema.override
@@ -1,0 +1,3 @@
+[org.gnome.desktop.media-handling:Phrog]
+automount=false
+

--- a/data/phrog-greetd-session
+++ b/data/phrog-greetd-session
@@ -17,7 +17,7 @@ PHOC_INI=/etc/phrog/phoc.ini
 # Need to set XDG_CURRENT_DESKTOP now, otherwise gnome-session defaults it to
 # "GNOME", which is a problem because default desktop files for Squeekboard and
 # phosh-osk-stub specify "OnlyShowIn=Phosh;"
-export XDG_CURRENT_DESKTOP=Phosh:GNOME
+export XDG_CURRENT_DESKTOP=Phrog:Phosh:GNOME
 
 export GNOME_SESSION_AUTOSTART_DIR=/usr/share/phrog/autostart:/etc/phrog/autostart
 


### PR DESCRIPTION
We e.g. don't want to mount any removable media and can add other overrides here.

See: https://gitlab.postmarketos.org/postmarketOS/pmaports/-/issues/4284

We had some other settings that would require slightly different defaults but I don't remember which one those were :cry: . Marking as draft until we know this is what we actually need to fix the referenced issues.