### PR TITLE
lockscreen: bridge homed users into AccountsService with visibility filtering

### DIFF
--- a/src/dbus.rs
+++ b/src/dbus.rs
@@ -255,3 +255,31 @@ pub mod user {
         fn xsession(&self) -> zbus::Result<String>;
     }
 }
+
+pub mod home1_manager {
+    //! # D-Bus interface proxy for: `org.freedesktop.home1.Manager`
+    use zbus::proxy;
+
+    #[proxy(
+        interface = "org.freedesktop.home1.Manager",
+        default_service = "org.freedesktop.home1",
+        default_path = "/org/freedesktop/home1"
+    )]
+    pub trait Manager {
+        /// ListHomes method
+        fn list_homes(
+            &self,
+        ) -> zbus::Result<
+            Vec<(
+                String,
+                u32,
+                String,
+                u32,
+                String,
+                String,
+                String,
+                zbus::zvariant::OwnedObjectPath,
+            )>,
+        >;
+    }
+}

--- a/src/user_session_page.rs
+++ b/src/user_session_page.rs
@@ -46,6 +46,8 @@ impl UserSessionPage {
 
 mod imp {
     use crate::dbus::accounts::AccountsProxy;
+    use crate::dbus::home1_manager::ManagerProxy;
+    use crate::dbus::user::UserProxy;
     use crate::session_object::SessionObject;
     use crate::shell::Shell;
     use crate::user::User;
@@ -65,6 +67,8 @@ mod imp {
     use libhandy::ActionRow;
     use std::cell::{Cell, OnceCell};
     use std::sync::OnceLock;
+    use std::time::Duration;
+    use zbus::zvariant::OwnedObjectPath;
 
     #[derive(CompositeTemplate, Default, Properties)]
     #[properties(wrapper_type = super::UserSessionPage)]
@@ -170,9 +174,9 @@ mod imp {
             glib::spawn_future_local(clone!(@weak self as this, @strong last_user => async move {
                 let accounts_proxy = AccountsProxy::new(&conn).await.unwrap();
 
-                for path in accounts_proxy.list_cached_users().await.unwrap() {
-                    users.append(&User::new(conn.clone(), path.into()));
-                }
+                sync_cached_accounts_users(&conn, &accounts_proxy, &users).await;
+                cache_homed_users(&accounts_proxy, &conn).await;
+                sync_cached_accounts_users(&conn, &accounts_proxy, &users).await;
 
                 // The initial user list has been populated. Select the first item in the list to
                 // ensure something is selected.
@@ -188,14 +192,15 @@ mod imp {
 
                 this.obj().set_ready(true);
 
-                let mut added_stream = accounts_proxy.receive_user_added().await.unwrap();
-                let mut deleted_stream = accounts_proxy.receive_user_deleted().await.unwrap();
+                let mut added_stream = accounts_proxy.receive_user_added().await.unwrap().fuse();
+                let mut deleted_stream = accounts_proxy.receive_user_deleted().await.unwrap().fuse();
+                let mut homed_tick = glib::interval_stream(Duration::from_secs(2)).fuse();
 
                 loop {
                     select! {
                         added = added_stream.next() => if let Some(added) = added {
                             if let Some(path) = added.args().ok().map(|v| v.user) {
-                                users.append(&User::new(conn.clone(), path));
+                                append_user_if_visible(&conn, &users, path.into()).await;
                             }
                         },
                         deleted = deleted_stream.next() => if let Some(deleted) = deleted {
@@ -207,6 +212,10 @@ mod imp {
                                     }
                                 }
                             }
+                        },
+                        _ = homed_tick.next() => {
+                            cache_homed_users(&accounts_proxy, &conn).await;
+                            sync_cached_accounts_users(&conn, &accounts_proxy, &users).await;
                         },
                     }
                 }
@@ -222,4 +231,60 @@ mod imp {
     impl WidgetImpl for UserSessionPage {}
     impl ContainerImpl for UserSessionPage {}
     impl BoxImpl for UserSessionPage {}
+
+    async fn sync_cached_accounts_users(
+        conn: &zbus::Connection,
+        accounts_proxy: &AccountsProxy<'_>,
+        users: &ListStore,
+    ) {
+        if let Ok(paths) = accounts_proxy.list_cached_users().await {
+            for path in paths {
+                append_user_if_visible(conn, users, path).await;
+            }
+        }
+    }
+
+    async fn cache_homed_users(accounts_proxy: &AccountsProxy<'_>, conn: &zbus::Connection) {
+        let Ok(homed_proxy) = ManagerProxy::new(conn).await else {
+            return;
+        };
+
+        if let Ok(homes) = homed_proxy.list_homes().await {
+            for (username, _, _, _, _, _, _, _) in homes {
+                if let Err(err) = accounts_proxy.cache_user(&username).await {
+                    glib::warn!("failed to cache homed user {}: {}", username, err);
+                }
+            }
+        }
+    }
+
+    async fn append_user_if_visible(
+        conn: &zbus::Connection,
+        users: &ListStore,
+        path: OwnedObjectPath,
+    ) {
+        if !user_path_is_visible(conn, &path).await {
+            return;
+        }
+
+        for user in users.iter::<User>().flatten() {
+            if user.path() == path.as_str() {
+                return;
+            }
+        }
+
+        users.append(&User::new(conn.clone(), path.into()));
+    }
+
+    async fn user_path_is_visible(conn: &zbus::Connection, path: &OwnedObjectPath) -> bool {
+        let Ok(user_proxy) = UserProxy::builder(conn).path(path).unwrap().build().await else {
+            return false;
+        };
+
+        let local_account = user_proxy.local_account().await.unwrap_or(true);
+        let system_account = user_proxy.system_account().await.unwrap_or(false);
+        let username = user_proxy.user_name().await.unwrap_or_default();
+
+        local_account && !system_account && username != "greetd"
+    }
 }

--- a/tests/homed_accounts_bridge.rs
+++ b/tests/homed_accounts_bridge.rs
@@ -1,0 +1,66 @@
+pub mod common;
+
+use gtk::glib;
+use gtk::glib::clone;
+use gtk::prelude::*;
+use gtk::subclass::prelude::*;
+use libhandy::prelude::ActionRowExt;
+use libphosh::prelude::ShellExt;
+use phrog::lockscreen::Lockscreen;
+use std::time::Duration;
+
+use common::dbus::{AccountsFixtureOptions, UserFixture};
+use common::*;
+
+#[test]
+fn test_homed_users_are_cached_and_system_users_hidden() {
+    let mut test = test_init(Some(TestOptions {
+        accounts_fixture: Some(AccountsFixtureOptions {
+            users: vec![
+                UserFixture::new("Guido", "agx", "guido.png", true, false),
+                UserFixture::new("Greeter", "greetd", "phoshi.png", true, true),
+                UserFixture::new("Homed User", "homed", "samcday.jpeg", true, false),
+            ],
+            cached_users: Some(vec!["agx".into(), "greetd".into()]),
+            homed_users: vec!["homed".into()],
+            ..Default::default()
+        }),
+        last_user: Some("agx".into()),
+        fake_greetd: Some(true),
+        ..Default::default()
+    }));
+
+    let ready_rx = test.ready_rx.clone();
+    let shell = test.shell.clone();
+    test.start(
+        "homed-accounts-bridge",
+        glib::spawn_future_local(clone!(@weak shell => async move {
+            let (_vp, _) = ready_rx.recv().await.unwrap();
+            glib::timeout_future(Duration::from_millis(2500)).await;
+
+            let lockscreen = shell
+                .lockscreen_manager()
+                .lockscreen()
+                .unwrap()
+                .downcast::<Lockscreen>()
+                .unwrap();
+            let usp = lockscreen.imp().user_session_page.get().unwrap();
+
+            let rows = usp.imp().box_users.children();
+            let usernames = rows
+                .iter()
+                .filter_map(|row| {
+                    row.downcast_ref::<libhandy::ActionRow>()
+                        .and_then(|row| row.subtitle())
+                        .map(|s| s.to_string())
+                })
+                .collect::<Vec<_>>();
+
+            assert!(usernames.contains(&"agx".to_string()));
+            assert!(usernames.contains(&"homed".to_string()));
+            assert!(!usernames.contains(&"greetd".to_string()));
+
+            fade_quit();
+        })),
+    );
+}


### PR DESCRIPTION
### Motivation
- AccountsService alone can miss users created/managed by `systemd-homed`, causing homed users to not appear in the chooser.  
- The UI currently shows every cached user verbatim, which can leak service/system accounts like `greetd`.  
- Add a pragmatic, portable bridge to discover homed users and make them visible via `AccountsService` while preserving `AccountsService` as the primary source of truth.  
- Provide test fixtures to exercise the bridge and visibility rules in integration tests.

### Description
- Added a `org.freedesktop.home1.Manager` DBus proxy (`ListHomes`) to `src/dbus.rs` so the runtime can discover homed-managed accounts via `home1`.  
- Implemented a homed-to-AccountsService bridge in `src/user_session_page.rs` that: seeds the chooser from `ListCachedUsers`, queries `ListHomes` and calls `CacheUser` for discovered homed accounts, then re-syncs the chooser from `AccountsService`, and runs a periodic reconciliation loop to keep things in sync.  
- Added account visibility filtering before appending users to the chooser using `local_account`, `system_account` and an explicit suppression of the `greetd` service account to avoid surfacing service/system accounts.  
- Extended the DBus test fixtures in `tests/common/dbus.rs` and `tests/common/mod.rs` to support configurable fixture options, `cache_user` on AccountsService, `local_account`/`system_account` properties on users, and a `home1` manager fixture.  
- Added an integration test `tests/homed_accounts_bridge.rs` that validates: a cached regular user remains visible, a homed user appears after the bridge caches it, and a system/service user (`greetd`) is filtered out.

### Testing
- Ran `cargo fmt` and `cargo fmt --check`, which completed successfully.  
- Ran `cargo test --no-run` to build the test suite, which failed in this environment because the system GLib development files were not available to `pkg-config` (error: missing `glib-2.0.pc`), so tests could not be executed here.  
- Added integration coverage via `tests/homed_accounts_bridge.rs` that can be executed in an environment with the required system dev packages (GLib, gtk, etc.) and DBus available; the test asserts homed caching, normal user visibility, and system-account filtering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998e8a548f08325a677d82e26db3419)

closes #144 