### PR TITLE
ci: add Packit propose_downstream automation for Fedora dist-git updates

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -36,3 +36,9 @@ jobs:
     enable_net: true
     owner: samcday
     project: phrog
+
+  # Open Fedora dist-git update PRs for upstream releases.
+  - job: propose_downstream
+    trigger: release
+    dist_git_branches:
+      - fedora-all


### PR DESCRIPTION
### Motivation
- Enable upstream-side automation so that new releases can automatically open Fedora dist-git update PRs using Packit's `propose_downstream` job.

### Description
- Add a `propose_downstream` job to the upstream `.packit.yaml` configured with `trigger: release` and `dist_git_branches: [fedora-all]` so release events open dist-git PRs.
- Keep existing COPR jobs and other Packit configuration unchanged and preserve `specfile_path` and `files_to_sync` entries.
- Commit created with message `ci: add packit propose_downstream job` updating `.packit.yaml`.

### Testing
- Ran `git diff --check` which reported no issues and the change was committed successfully. 
- Attempted `yamllint .packit.yaml` but `yamllint` is not available in this environment, so YAML linting was not performed.
- Verified the resulting `.packit.yaml` contains the new `propose_downstream` job at lines 40–44 via `git show` and `nl` output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69993e0a80348325bec26eeb5f0b3271)