### PR TITLE
Allow to configure pam service

### DIFF
--- a/data/greetd-config.toml.in
+++ b/data/greetd-config.toml.in
@@ -1,3 +1,6 @@
+[general]
+service = "@GENERAL_SERVICE@"
+
 [terminal]
 vt = @VT@
 

--- a/debian/phrog.pam
+++ b/debian/phrog.pam
@@ -1,0 +1,9 @@
+#%PAM-1.0
+@include common-auth
+@include common-account
+
+auth        optional        pam_gnome_keyring.so
+
+@include common-session
+
+session     optional        pam_gnome_keyring.so auto_start

--- a/debian/rules
+++ b/debian/rules
@@ -13,7 +13,7 @@ export INSTALL_DIR=$(CURDIR)/debian/phrog
 # during build and delete it afterwards
 override_dh_auto_build:
 	HOME=$(CURDIR)/debian/tmp_home cargo build
-	HOME=$(CURDIR)/debian/tmp_home cargo xtask dist-data phrog.toml --greetd-vt 7 --greetd-user _greetd
+	HOME=$(CURDIR)/debian/tmp_home cargo xtask dist-data phrog.toml --greetd-vt 7 --greetd-user _greetd --greetd-general-service phrog
 
 override_dh_auto_install:
 	install -D -m0755 target/$(DEB_HOST_RUST_TYPE)/debug/phrog \

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -44,6 +44,8 @@ enum Commands {
         /// User greetd should use for phrog.
         #[arg(long)]
         greetd_user: String,
+        #[arg(long, default_value = "greetd")]
+        greetd_general_service: String,
     },
     /// Extract release notes from NEWS.
     ReleaseNotes {
@@ -69,7 +71,8 @@ fn run() -> Result<()> {
             file_name,
             greetd_vt,
             greetd_user,
-        } => dist_data(&file_name, greetd_vt, &greetd_user),
+            greetd_general_service,
+        } => dist_data(&file_name, greetd_vt, &greetd_user, &greetd_general_service),
         Commands::ReleaseNotes { version, rc } => release_notes(&version, rc),
     }
 }
@@ -127,7 +130,12 @@ fn bump(version: &str) -> Result<()> {
     Ok(())
 }
 
-fn dist_data(file_name: &str, greetd_vt: u8, greetd_user: &str) -> Result<()> {
+fn dist_data(
+    file_name: &str,
+    greetd_vt: u8,
+    greetd_user: &str,
+    greetd_general_service: &str,
+) -> Result<()> {
     let root = project_root()?;
     let out_path = dist_data_path(&root, file_name)?;
     let out_dir = out_path
@@ -135,7 +143,10 @@ fn dist_data(file_name: &str, greetd_vt: u8, greetd_user: &str) -> Result<()> {
         .ok_or_else(|| format!("output path '{}' has no parent", out_path.display()))?;
 
     fs::create_dir_all(&out_dir)?;
-    fs::write(&out_path, render_greetd_config(greetd_vt, greetd_user))?;
+    fs::write(
+        &out_path,
+        render_greetd_config(greetd_vt, greetd_user, greetd_general_service),
+    )?;
 
     println!("Generated {}", out_path.display());
 
@@ -193,10 +204,11 @@ fn parse_version(version: &str) -> Result<ReleaseVersion> {
     })
 }
 
-fn render_greetd_config(greetd_vt: u8, greetd_user: &str) -> String {
+fn render_greetd_config(greetd_vt: u8, greetd_user: &str, greetd_general_service: &str) -> String {
     GREETD_CONFIG_TEMPLATE
         .replace("@VT@", &greetd_vt.to_string())
         .replace("@USER@", greetd_user)
+        .replace("@GENERAL_SERVICE@", greetd_general_service)
 }
 
 fn dist_data_path(root: &Path, file_name: &str) -> Result<PathBuf> {


### PR DESCRIPTION
On Debian we relied  on greetd using a pam config to unlock session keyrings. This has been dropped so provide a way to configure PAM so it's useful in Phosh.

Related Debian issue: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1143492